### PR TITLE
Add Ruby 3.0 to versions in CI workflow

### DIFF
--- a/.github/workflows/y.yml
+++ b/.github/workflows/y.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.7, 2.6, 2.5 ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
Having attempted to add Ruby 3.0 to the `reline` workflow (https://github.com/ruby/reline/pull/238) I am making similar changes here as well as in the `vterm-gem` https://github.com/aycabta/vterm-gem/pull/7