### PR TITLE
CI: Add Ruby 3.0 to the matrix

### DIFF
--- a/.github/workflows/y.yml
+++ b/.github/workflows/y.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ 2.7, 2.6, 2.5 ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
This PR adds the latest release of Ruby.