### PR TITLE
pass rake test on windows

### DIFF
--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -24,7 +24,7 @@ module Yamatanooroti::WindowsDefinition
   typealias 'LPCVOID', 'void*'
   typealias 'LPDWORD', 'void*'
   typealias 'LPOVERLAPPED', 'void*'
-  typealias 'WCHAR', 'SHORT'
+  typealias 'WCHAR', 'unsigned short'
   typealias 'LPCWCH', 'void*'
   typealias 'LPSTR', 'void*'
   typealias 'LPCCH', 'void*'

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -264,14 +264,14 @@ module Yamatanooroti::WindowsTestCaseModule
   private def mb2wc(str)
     size = DL.MultiByteToWideChar(65001, 0, str, str.bytesize, '', 0)
     converted_str = String.new("\x00" * (size * 2), encoding: 'ASCII-8BIT')
-    DL.MultiByteToWideChar(65001, 0, str, str.bytesize, converted_str, converted_str.bytesize)
+    DL.MultiByteToWideChar(65001, 0, str, str.bytesize, converted_str, size)
     converted_str
   end
 
   private def wc2mb(str)
-    size = DL.WideCharToMultiByte(65001, 0, str, str.bytesize, '', 0, 0, 0)
-    converted_str = "\x00" * (size * 2)
-    DL.WideCharToMultiByte(65001, 0, str, str.bytesize, converted_str, converted_str.bytesize, 0, 0)
+    size = DL.WideCharToMultiByte(65001, 0, str, str.bytesize / 2, '', 0, 0, 0)
+    converted_str = "\x00" * size
+    DL.WideCharToMultiByte(65001, 0, str, str.bytesize / 2, converted_str, converted_str.bytesize, 0, 0)
     converted_str
   end
 

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -367,10 +367,10 @@ module Yamatanooroti::WindowsTestCaseModule
 
   def write(str)
     sleep @wait
-    str.force_encoding(Encoding::ASCII_8BIT).tr!("\n", "\r")
     records = Fiddle::Pointer.malloc(DL::INPUT_RECORD_WITH_KEY_EVENT.size * str.size * 2, DL::FREE)
     str.chars.each_with_index do |c, i|
-      byte = c.ord
+      c = "\r" if c == "\n"
+      byte = c.getbyte(0)
       if c.bytesize == 1 and byte.allbits?(0x80) # with Meta key
         c = (byte ^ 0x80).chr
         control_key_state = DL::LEFT_ALT_PRESSED

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -537,7 +537,11 @@ module Yamatanooroti::WindowsTestCaseModule
     launch(command.map{ |c| quote_command_arg(c) }.join(' '))
     case startup_message
     when String
-      check_startup_message = ->(message) { message.start_with?(startup_message) }
+      check_startup_message = ->(message) {
+        message.start_with?(
+          startup_message.each_char.each_slice(width).map(&:join).join("\0").gsub(/ *\0/, "\n")
+        )
+      }
     when Regexp
       check_startup_message = ->(message) { startup_message.match?(message) }
     end

--- a/lib/yamatanooroti/windows.rb
+++ b/lib/yamatanooroti/windows.rb
@@ -491,8 +491,8 @@ module Yamatanooroti::WindowsTestCaseModule
     region = DL::SMALL_RECT.malloc
     region.Left = 0
     region.Top = 0
-    region.Right = @width
-    region.Bottom = @height
+    region.Right = @width - 1
+    region.Bottom = @height - 1
     r = DL.ReadConsoleOutputW(@output_handle, char_info_matrix, @height * 65536 + @width, 0, region)
     error_message(r, "ReadConsoleOutputW")
     screen = []


### PR DESCRIPTION
I needed to pass test, set Encoding.default_external to Windows-31J

ruby 2.7
unset RUBYOPT required (rubyinstaller does RUBYOPT=-Eutf-8. if unset, default: windows locale)

ruby 3.0
set RUBYOPT=-EWindows-31J (default: utf-8)
